### PR TITLE
fix: correct Llama model name, handle JSON spacing errors, and prevent mode conflicts

### DIFF
--- a/tasks/longwiki/longwiki_main.py
+++ b/tasks/longwiki/longwiki_main.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
     parser.add_argument('--do_extract_only', default=False, action='store_true')
 
     parser.add_argument('--model', type=str, default='meta-llama/Llama-3.1-405B-Instruct-FP8', help='model that is being "TESTED"')
-    parser.add_argument('--q_generator', type=str, default='meta-llama/Meta-Llama-3.1-70B-Instruct', help='model that is used for question generation')
+    parser.add_argument('--q_generator', type=str, default='meta-llama/Llama-3.1-70B-Instruct', help='model that is used for question generation')
 
     parser.add_argument('--claim_extractor', type=str, default='meta-llama/Llama-3.1-405B-Instruct-FP8', help='model that is used for claim extraction')
     parser.add_argument('--abstain_evaluator', type=str, default="meta-llama/Llama-3.1-70B-Instruct", help='model that is used for abstantion evaluation')

--- a/tasks/longwiki/longwiki_utils.py
+++ b/tasks/longwiki/longwiki_utils.py
@@ -168,4 +168,3 @@ def jsonify_ans(raw_responses, eval_prompts, evaluator, key):
                 print("<<< PASS >>>")
 
     return jsonifyed_res
-

--- a/tasks/longwiki/longwiki_utils.py
+++ b/tasks/longwiki/longwiki_utils.py
@@ -127,7 +127,7 @@ def jsonify_ans(raw_responses, eval_prompts, evaluator, key):
             return '{{"{}":true}}'.format(key)
         else:
             return -1
-        
+
     jsonifyed_res  = []
     for r, p in zip(raw_responses, eval_prompts):
         
@@ -168,3 +168,4 @@ def jsonify_ans(raw_responses, eval_prompts, evaluator, key):
                 print("<<< PASS >>>")
 
     return jsonifyed_res
+

--- a/tasks/longwiki/longwiki_utils.py
+++ b/tasks/longwiki/longwiki_utils.py
@@ -120,6 +120,7 @@ def model_eval_step(evaluator, prompts, max_token=512, batch_size=16, max_worker
 def jsonify_ans(raw_responses, eval_prompts, evaluator, key):
 
     def check_validity(gen):
+        gen = gen.replace(" ", "").lower()
         if '{{"{}":false}}'.format(key) in gen.lower():
             return '{{"{}":false}}'.format(key)
         elif '{{"{}":true}}'.format(key) in gen.lower():

--- a/tasks/shortform/precise_wikiqa.py
+++ b/tasks/shortform/precise_wikiqa.py
@@ -264,13 +264,14 @@ if __name__ == '__main__':
     print(f"Running {TASKNAME} with model {model_name}")
 
     QAs_df = None
+
+    QA_OUTPUT_PATH = f'data/precise_qa/save/qa_{args.wiki_src}_{model_name}_{args.mode}.jsonl' \
+        if args.qa_output_path == "" \
+        else args.qa_output_path
+    print(QA_OUTPUT_PATH)
+
     if args.do_generate_prompt:
         # 1. Generate QA pairs
-        QA_OUTPUT_PATH = f'data/precise_qa/save/qa_{args.wiki_src}_{model_name}_{args.mode}.jsonl'\
-                            if args.qa_output_path == "" \
-                                else args.qa_output_path
-        print(QA_OUTPUT_PATH)
-
         if os.path.exists(QA_OUTPUT_PATH):
             QAs = [line for line in jsonlines.open(QA_OUTPUT_PATH, 'r')]
             print("DATA EXISTS!! Reading from existing file ", len(QAs))


### PR DESCRIPTION
# What I did
### 1. Model name error in `longwiki_main.py` code 66 line
- Model name error. Huggingface lamma 3.1 70B model name is meta-llama/Llama-3.1-70B-Instruct.
<img width="2732" height="144" alt="image" src="https://github.com/user-attachments/assets/5f11eb3d-a498-4c73-8f00-8cae538c6069" />


### 2. Fix error caused by incorrect spacing when the model doesn’t follow prompt instructions at `longwiki_utils.py` `check_validity` function at 122 line.
- Fix error caused by incorrect spacing when the model doesn’t follow prompt json instructions.

<img width="1212" height="436" alt="image" src="https://github.com/user-attachments/assets/dd9f1ceb-5984-4c74-acb2-62b1f43a67e6" />

### 3. Prevent mode selection conflict at `precise_wikiqa.py` at 269 line.
- If QA_OUTPUT_PATH is specified in condition of do_prompt_generate, we can’t choose between do_prompt_generate, do_inference, or do_eval

<img width="1712" height="336" alt="image" src="https://github.com/user-attachments/assets/5e430b84-9b8f-4099-ac3a-4418a1e0952c" />
